### PR TITLE
chore: root 에 check script, studio script 추가

### DIFF
--- a/apps/dash-board/package.json
+++ b/apps/dash-board/package.json
@@ -12,7 +12,8 @@
     "playwright:install": "playwright install",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e:headed": "playwright test --headed",
+    "check": "pnpm run lint && pnpm run check-types"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.10",

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -8,7 +8,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "biome lint . --write",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "check": "pnpm run lint && pnpm run check-types"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.18.0",

--- a/apps/node-server/package.json
+++ b/apps/node-server/package.json
@@ -9,6 +9,7 @@
     "start": "node dist/index.cjs",
     "lint": "biome lint . --write",
     "check-types": "tsc --noEmit",
+    "check": "pnpm run lint && pnpm run check-types",
     "test": "vitest run __test__/index.test.ts",
     "test:e2e": "start-server-and-test start 5050 test:e2e:run",
     "test:e2e:run": "vitest run __test__/e2e --config vitest.e2e.config.ts"

--- a/apps/solves/package.json
+++ b/apps/solves/package.json
@@ -8,6 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "biome lint . --write",
+    "check": "pnpm run lint && pnpm run check-types",
     "check-types": "tsc --noEmit",
     "playwright:install": "playwright install",
     "test:e2e": "playwright test",

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "drizzle-kit";
+import "@workspace/env";
+
+const dialect = "postgresql";
+
+// @ts-ignore
+const url = process.env.POSTGRES_URL!;
+
+const out = "./src/migrations";
+
+export default defineConfig({
+  out,
+  dialect,
+  dbCredentials: {
+    url,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -18,17 +18,21 @@
     "format": "biome check . --apply",
     "check-types": "turbo run check-types",
     "changeset": "changeset",
+    "check": "turbo run check",
     "changeset:version": "changeset version",
     "changeset:publish": "pnpm build && changeset publish",
     "clean": "tsx scripts/clean.ts",
     "docker:pg": "docker run --name local-pg -e POSTGRES_PASSWORD=your_password -e POSTGRES_USER=your_username -e POSTGRES_DB=your_database_name -p 5432:5432 -d postgres",
-    "docker:redis": "docker run --name local-redis -p 6379:6379 -d redis:7-alpine"
+    "docker:redis": "docker run --name local-redis -p 6379:6379 -d redis:7-alpine",
+    "db:studio": "drizzle-kit studio"
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.2",
     "@changesets/cli": "^2.29.7",
     "@playwright/test": "^1.55.1",
+    "@workspace/env": "workspace:*",
     "danger": "^13.0.4",
+    "drizzle-kit": "^0.31.5",
     "glob": "^11.0.3",
     "inquirer": "^12.9.6",
     "rimraf": "^6.0.1",

--- a/packages/env/__test__/unit.test.ts
+++ b/packages/env/__test__/unit.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
-import { load } from '../src/load';
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { load } from "../src/load";
 
-describe('unit test', () => {
+describe("unit test", () => {
   const testRoot = join(process.cwd(), `test-env-${new Date().toString()}`);
 
   beforeEach(() => {
@@ -14,62 +14,71 @@ describe('unit test', () => {
     rmSync(testRoot, { recursive: true, force: true });
   });
 
-  it('should load variables from .env', () => {
-    writeFileSync(join(testRoot, '.env'), 'VAR1=from-env\nVAR2=from-env');
+  it("should load variables from .env", () => {
+    writeFileSync(join(testRoot, ".env"), "VAR1=from-env\nVAR2=from-env");
 
     const result = load(testRoot);
     expect(result).toEqual({
-      VAR1: 'from-env',
-      VAR2: 'from-env',
+      VAR1: "from-env",
+      VAR2: "from-env",
     });
   });
 
-  it('should override variables with .env.NODE_ENV', () => {
-    process.env.NODE_ENV = 'test';
-    writeFileSync(join(testRoot, '.env'), 'VAR1=from-env\nVAR2=from-env');
-    writeFileSync(join(testRoot, '.env.test'), 'VAR2=from-env-test\nVAR3=from-env-test');
+  it("should override variables with .env.NODE_ENV", () => {
+    process.env.NODE_ENV = "test";
+    writeFileSync(join(testRoot, ".env"), "VAR1=from-env\nVAR2=from-env");
+    writeFileSync(
+      join(testRoot, ".env.test"),
+      "VAR2=from-env-test\nVAR3=from-env-test",
+    );
 
     const result = load(testRoot);
     expect(result).toEqual({
-      VAR2: 'from-env-test',
-      VAR3: 'from-env-test',
-      VAR1: 'from-env',
+      VAR2: "from-env-test",
+      VAR3: "from-env-test",
+      VAR1: "from-env",
     });
   });
 
-  it('should override variables with .env.local', () => {
-    process.env.NODE_ENV = 'test';
-    writeFileSync(join(testRoot, '.env'), 'VAR1=from-env\nVAR2=from-env');
-    writeFileSync(join(testRoot, '.env.test'), 'VAR2=from-env-test\nVAR3=from-env-test');
-    writeFileSync(join(testRoot, '.env.local'), 'VAR3=from-env-local\nVAR4=from-env-local');
+  it("should override variables with .env.local", () => {
+    process.env.NODE_ENV = "test";
+    writeFileSync(join(testRoot, ".env"), "VAR1=from-env\nVAR2=from-env");
+    writeFileSync(
+      join(testRoot, ".env.test"),
+      "VAR2=from-env-test\nVAR3=from-env-test",
+    );
+    writeFileSync(
+      join(testRoot, ".env.local"),
+      "VAR3=from-env-local\nVAR4=from-env-local",
+    );
 
     const result = load(testRoot);
     expect(result).toEqual({
-      VAR3: 'from-env-local',
-      VAR4: 'from-env-local',
-      VAR2: 'from-env-test',
-      VAR1: 'from-env',
+      VAR3: "from-env-local",
+      VAR4: "from-env-local",
+      VAR2: "from-env-test",
+      VAR1: "from-env",
     });
   });
 
-  it('should not override existing variables', () => {
-    process.env.NODE_ENV = 'production';
-    writeFileSync(join(testRoot, '.env'), 'VAR=from-env');
-    writeFileSync(join(testRoot, '.env.production'), 'VAR=from-env-production');
-    writeFileSync(join(testRoot, '.env.local'), 'VAR=from-env-local');
+  it("should not override existing variables", () => {
+    process.env.NODE_ENV = "production";
+    writeFileSync(join(testRoot, ".env"), "VAR=from-env");
+    writeFileSync(join(testRoot, ".env.production"), "VAR=from-env-production");
+    writeFileSync(join(testRoot, ".env.local"), "VAR=from-env-local");
 
     const result = load(testRoot);
     expect(result).toEqual({
-      VAR: 'from-env-local',
+      VAR: "from-env-local",
     });
   });
 
-  it('should handle missing files gracefully', () => {
-    process.env.NODE_ENV = 'staging';
-    writeFileSync(join(testRoot, '.env'), 'VAR=from-env');
+  it("should handle missing files gracefully", () => {
+    process.env.NODE_ENV = "staging";
+    writeFileSync(join(testRoot, ".env"), "VAR=from-env");
     const result = load(testRoot);
     expect(result).toEqual({
-      VAR: 'from-env',
+      VAR: "from-env",
     });
   });
 });

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -6,7 +6,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "biome lint . --write",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "check": "pnpm run lint && pnpm run check-types && pnpm run test"
   },
   "exports": {
     ".": "./src/index.ts"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -7,7 +7,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "biome lint . --write",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "check": "pnpm run lint && pnpm run check-types && pnpm run test"
   },
   "exports": {
     ".": "./src/base/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,15 @@ importers:
       '@playwright/test':
         specifier: ^1.55.1
         version: 1.55.1
+      '@workspace/env':
+        specifier: workspace:*
+        version: link:packages/env
       danger:
         specifier: ^13.0.4
         version: 13.0.4
+      drizzle-kit:
+        specifier: ^0.31.5
+        version: 0.31.5
       glob:
         specifier: ^11.0.3
         version: 11.0.3
@@ -3206,6 +3212,10 @@ packages:
 
   drizzle-kit@0.31.4:
     resolution: {integrity: sha512-tCPWVZWZqWVx2XUsVpJRnH9Mx0ClVOf5YUHerZ5so1OKSlqww4zy1R5ksEdGRcO3tM3zj0PYN6V48TbQCL1RfA==}
+    hasBin: true
+
+  drizzle-kit@0.31.5:
+    resolution: {integrity: sha512-+CHgPFzuoTQTt7cOYCV6MOw2w8vqEn/ap1yv4bpZOWL03u7rlVRQhUY0WYT3rHsgVTXwYQDZaSUJSQrMBUKuWg==}
     hasBin: true
 
   drizzle-orm@0.44.5:
@@ -7473,6 +7483,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  drizzle-kit@0.31.5:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.10
+      esbuild-register: 3.6.0(esbuild@0.25.10)
+    transitivePeerDependencies:
+      - supports-color
+
   drizzle-orm@0.44.5(@opentelemetry/api@1.9.0)(@types/pg@8.15.5)(kysely@0.28.7)(pg@8.16.3):
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -7530,6 +7549,13 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
+
+  esbuild-register@3.6.0(esbuild@0.25.10):
+    dependencies:
+      debug: 4.4.3
+      esbuild: 0.25.10
+    transitivePeerDependencies:
+      - supports-color
 
   esbuild-register@3.6.0(esbuild@0.25.9):
     dependencies:

--- a/services/auth/package.json
+++ b/services/auth/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "lint": "biome lint . --write",
     "check-types": "tsc --noEmit",
+    "check": "pnpm run lint && pnpm run check-types",
     "db:generate": "drizzle-kit generate",
     "db:reset": "drizzle-kit drop && drizzle-kit push",
     "db:push": "drizzle-kit push",

--- a/services/todo/package.json
+++ b/services/todo/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "lint": "biome lint . --write",
     "check-types": "tsc --noEmit",
+    "check": "pnpm run lint && pnpm run check-types",
     "db:generate": "drizzle-kit generate",
     "db:reset": "drizzle-kit drop && drizzle-kit push",
     "db:push": "drizzle-kit push",

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,9 @@
     "check-types": {
       "dependsOn": ["^check-types"]
     },
+    "check": {
+      "dependsOn": ["^check"]
+    },
     "test": {
       "dependsOn": ["^test"]
     },


### PR DESCRIPTION
# 배포전 미리 확인해야할 lint,type check 를 통합한   script 추가 

### postgresql studio 실행 스크립트  ( 매번 studio 를 킬때 경로를 옮겨야하는 것을 위한 )

- root 에서 실행 할 경우 
```terminal
pnpm db:studio
```

- 다른 경로에서 실행 할 경우  (-w 는 루트에서 실행한다는 의미)
```terminal
pnpm -w db:studio
```




### Lint & Type check 

- root 에서 실행 할 경우 
```terminal
pnpm check
```

- 다른 경로에서 실행 할 경우  (-w 는 루트에서 실행한다는 의미)
```terminal
pnpm -w check
```
